### PR TITLE
调整十周年样式获取前缀为使用get.rawName

### DIFF
--- a/src/ui/prefixMark.js
+++ b/src/ui/prefixMark.js
@@ -325,7 +325,7 @@ export const prefixMarkModule = {
 		// 更新主将名称显示（去除前缀）
 		const nameElement = playerElement.node?.name;
 		if (nameElement) {
-			nameElement.innerText = get.rawName2(character);
+			nameElement.innerText = get.plainText(get.rawName2(character));
 		}
 	},
 

--- a/src/ui/prefixMark.js
+++ b/src/ui/prefixMark.js
@@ -325,7 +325,7 @@ export const prefixMarkModule = {
 		// 更新主将名称显示（去除前缀）
 		const nameElement = playerElement.node?.name;
 		if (nameElement) {
-			nameElement.innerText = get.plainText(get.rawName2(character));
+			nameElement.innerText = get.rawName2(character);
 		}
 	},
 

--- a/src/ui/prefixMark.js
+++ b/src/ui/prefixMark.js
@@ -325,7 +325,7 @@ export const prefixMarkModule = {
 		// 更新主将名称显示（去除前缀）
 		const nameElement = playerElement.node?.name;
 		if (nameElement) {
-			nameElement.innerText = get.rawName2(character);
+			nameElement.innerText = get.rawName(character);
 		}
 	},
 


### PR DESCRIPTION
由牢骚哥的牢大陆逊发现十周年样式获取前缀使用的是get.rawName2，对于有_ab翻译的武将，如高达一号，最后为神前缀，名字高达一号显然不对，牢大陆逊_ab翻译甚至用了poptip